### PR TITLE
Add relative_path parameter to override Facebook endpoint

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -237,7 +237,19 @@ class FacebookAdsApi(object):
 
         self._num_requests_attempted += 1
 
-        if not isinstance(path, six.string_types):
+        batch = params.get('batch')
+        relative_url = None
+
+        if batch and isinstance(batch, list):
+            relative_url = batch[0].get('relative_url')
+
+        if relative_url:
+            path = "/".join((
+                self._session.GRAPH,
+                self.API_VERSION,
+                relative_url,
+            ))
+        elif not isinstance(path, six.string_types):
             # Path is not a full path
             path = "/".join((
                 self._session.GRAPH,

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -237,19 +237,7 @@ class FacebookAdsApi(object):
 
         self._num_requests_attempted += 1
 
-        batch = params.get('batch')
-        relative_url = None
-
-        if batch and isinstance(batch, list):
-            relative_url = batch[0].get('relative_url')
-
-        if relative_url:
-            path = "/".join((
-                self._session.GRAPH,
-                self.API_VERSION,
-                relative_url,
-            ))
-        elif not isinstance(path, six.string_types):
+        if not isinstance(path, six.string_types):
             # Path is not a full path
             path = "/".join((
                 self._session.GRAPH,

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -459,6 +459,7 @@ class AbstractCrudObject(AbstractObject):
         files=None,
         params=None,
         success=None,
+        relative_path=None
     ):
         """Creates the object by calling the API.
 
@@ -487,6 +488,9 @@ class AbstractCrudObject(AbstractObject):
         params = {} if not params else params.copy()
         params.update(self.export_data())
 
+        # some private endpoints require a custom relative_path
+        relative_path = relative_path or (self.get_parent_id_assured(), self.get_endpoint())
+
         if batch is not None:
             def callback_success(response):
                 self._set_data(response.json())
@@ -501,7 +505,7 @@ class AbstractCrudObject(AbstractObject):
 
             batch_call = batch.add(
                 'POST',
-                (self.get_parent_id_assured(), self.get_endpoint()),
+                relative_path,
                 params=params,
                 files=files,
                 success=callback_success,
@@ -511,7 +515,7 @@ class AbstractCrudObject(AbstractObject):
         else:
             response = self.get_api_assured().call(
                 'POST',
-                (self.get_parent_id_assured(), self.get_endpoint()),
+                relative_path,
                 params=params,
                 files=files,
             )
@@ -527,6 +531,7 @@ class AbstractCrudObject(AbstractObject):
         fields=None,
         params=None,
         success=None,
+        relative_path=None,
     ):
         """Reads the object by calling the API.
 
@@ -591,6 +596,7 @@ class AbstractCrudObject(AbstractObject):
         files=None,
         params=None,
         success=None,
+        relative_path=None,
     ):
         """Updates the object by calling the API with only the changes recorded.
 
@@ -652,6 +658,7 @@ class AbstractCrudObject(AbstractObject):
         failure=None,
         params=None,
         success=None,
+        relative_path=None,
     ):
         """Deletes the object by calling the API with the DELETE http method.
 
@@ -793,7 +800,7 @@ class Activity(AbstractObject):
         return 'activities'
 
 
-class AdAccount(CannotCreate, CannotDelete, AbstractCrudObject):
+class AdAccount(CannotDelete, AbstractCrudObject):
 
     class Field(object):
         account_groups = 'account_groups'
@@ -1370,6 +1377,7 @@ class AdImage(CannotUpdate, AbstractCrudObject):
         files=None,
         params=None,
         success=None,
+        relative_path=None,
     ):
         """Uploads filename and creates the AdImage object from it.
 
@@ -1404,6 +1412,7 @@ class AdImage(CannotUpdate, AbstractCrudObject):
         fields=None,
         params=None,
         success=None,
+        relative_path=None,
     ):
         if self[AdImage.Field.id]:
             _, image_hash = self[AdImage.Field.id].split(':')


### PR DESCRIPTION
This adds the ability to pass relative_url to remote_create allowing the business/adaccount endpoint to be set in order to create adaccounts

@derwiki-adroll 
