### PR TITLE
fix remote_delete signature to include relative_path for CanArchive obje...

### DIFF
--- a/facebookads/mixins.py
+++ b/facebookads/mixins.py
@@ -52,7 +52,8 @@ class CanArchive(object):
         self,
         batch=None,
         failure=None,
-        success=None
+        success=None,
+        relative_path=None,
     ):
         return self.remote_update(
             params={

--- a/facebookads/mixins.py
+++ b/facebookads/mixins.py
@@ -53,7 +53,7 @@ class CanArchive(object):
         batch=None,
         failure=None,
         success=None,
-        relative_path=None,
+        relative_path=None
     ):
         return self.remote_update(
             params={


### PR DESCRIPTION
so apparently there is this notion of a CanArchive mixin that has its own remote_delete, all the remote_\* methods were updated to take a relative_path url in the pr https://github.com/SemanticSugar/facebook-python-ads-sdk/pull/3

@derwiki-adroll @grantt 
