### PR TITLE
Add get_client_pages to Business

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -2132,6 +2132,21 @@ class Business(CannotCreate, CannotDelete, AbstractCrudObject):
         params['summary'] = params.get('summary')
         return self.iterate_edge(Insights, fields, params)
 
+    def get_client_pages(self, fields=None, params=None):
+        return self.iterate_edge(ClientPage, fields, params)
+
+class ClientPage(AbstractCrudObject, CannotCreate, CannotDelete):
+
+    class Field(object):
+        id = 'id'
+        category = 'category'
+        category_list = 'category_list'
+        name = 'name'
+
+    @classmethod
+    def get_endpoint(cls):
+        return 'client_pages'
+
 
 class ProductCatalog(AbstractCrudObject):
 

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -2147,7 +2147,7 @@ class Business(CannotCreate, CannotDelete, AbstractCrudObject):
             params=params
         )
 
-class ClientPage(AbstractCrudObject, CannotCreate, CannotDelete):
+class ClientPage(AbstractCrudObject, CannotCreate, CannotDelete, CannotUpdate):
 
     class Field(object):
         id = 'id'

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -2135,6 +2135,18 @@ class Business(CannotCreate, CannotDelete, AbstractCrudObject):
     def get_client_pages(self, fields=None, params=None):
         return self.iterate_edge(ClientPage, fields, params)
 
+    def send_page_invite(self, page_id, access_type, permitted_roles):
+        params = {
+            'page_id': page_id,
+            'access_type': access_type,
+            'permitted_roles': permitted_roles,
+        }
+        return self.get_api_assured().call(
+            'POST',
+            (self.get_id_assured(), 'pages'),
+            params=params
+        )
+
 class ClientPage(AbstractCrudObject, CannotCreate, CannotDelete):
 
     class Field(object):
@@ -2147,6 +2159,17 @@ class ClientPage(AbstractCrudObject, CannotCreate, CannotDelete):
     def get_endpoint(cls):
         return 'client_pages'
 
+    def assign_permissions(self, business, user, role):
+        params = {
+            'business': business,
+            'user': user,
+            'role': role,
+        }
+        return self.get_api_assured().call(
+            'POST',
+            (self.get_id_assured(), 'userpermissions'),
+            params=params
+        )
 
 class ProductCatalog(AbstractCrudObject):
 


### PR DESCRIPTION
We can use this to simplify the adroll.backend.tasks.facebook.invite_pages task.

Instead of the homebrewed thing that we use:

``` python
def process_page_data(pages_info):
    """do page processing"""
c = FacebookBusinessClient(logger=logger)
for pages in c.get_paged_data("{}/client_pages".format(app_credentials.business_id), limit=1000):
    process_page_data(pages)
```

we can do this:

``` python
business = facebookads.objects.Business(app_credentials.business_id)
for account in uninvited_accounts:
    business.send_page_invite(account.fbx_page_id, "AGENCY", ["ADVERTISER", "INSIGHTS_ANALYST"]

for page in business.get_client_pages(params={'limit': 1000}):
    page.assign_permissions(business['id'], seat_creds.id, "ADVERTISER")
```

It looks like the sdk client makes it a pretty trivial task to iterate over object endpoints, we just have to slowly chip away at our own client and add more stuff to this fork.

Thoughts? @nilesnelson @james-kelly @victorres11 @grantt 
