### PR TITLE
Bump api version to v2.3

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -135,7 +135,7 @@ class FacebookAdsApi(object):
 
     SDK_VERSION = '2.3.1'
 
-    API_VERSION = 'v2.2'
+    API_VERSION = 'v2.3'
 
     HTTP_METHOD_GET = 'GET'
 


### PR DESCRIPTION
Bumping the api version on our facebook-python-ads-sdk branch so facebookadmanager starts using v2.3

@nilesnelson @james-kelly @victorres11 
