### PR TITLE
Update our fork of the facebook SDK to not have a hard requirement on a certain version of pycountry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# Facebook Business SDK for Python
+# NextRoll's fork of the Facebook Business SDK for Python
 
+To deploy to artifactory:
+```
+python setup.py sdist upload -r pip-adroll
+```
 [![Build Status](https://travis-ci.org/facebook/facebook-python-business-sdk.svg)](https://travis-ci.org/facebook/facebook-python-business-sdk)
 
 ### Introduction

--- a/facebook_business/__init__.py
+++ b/facebook_business/__init__.py
@@ -21,7 +21,7 @@
 from facebook_business.session import FacebookSession
 from facebook_business.api import FacebookAdsApi
 
-__version__ = '6.0.0'
+__version__ = '6.0.0b2'
 __all__ = [
     'session',
     'objects',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests >= 2.3.0
 six >= 1.7.3
 curlify >= 2.1.0
-pycountry >= 19.8.18
+pycountry >= 1.10

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebook_business'
-PACKAGE_VERSION = '6.0.0'
+PACKAGE_VERSION = '6.0.0b2'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-business-sdk'


### PR DESCRIPTION
Like the title says.
Requiring that specific version breaks everything when we try to use the v6 sdk in AdRoll.