### PR TITLE
ZUCK-7716: Remove `params` keys from URL if `response['paging']['next']` is present (FB bug)

### DIFF
--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -848,7 +848,8 @@ class Cursor(object):
 
         if 'paging' in response and 'next' in response['paging']:
             self._path = response['paging']['next']
-            self.params = {}
+            # Comment line below because of the params bug present in FB end
+            # self.params = {}
         else:
             # Indicate if this was the last page
             self._finished_iteration = True

--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -33,6 +33,7 @@ from facebook_business.utils import urls
 from contextlib import contextmanager
 import copy
 from six.moves import http_client
+from urllib.parse import parse_qs, urlparse
 import os
 import json
 import six
@@ -848,8 +849,13 @@ class Cursor(object):
 
         if 'paging' in response and 'next' in response['paging']:
             self._path = response['paging']['next']
-            # Comment line below because of the params bug present in FB end
-            # self.params = {}
+            parsed_url = urlparse(self._path)
+            parsed_qs = parse_qs(parsed_url.query)
+
+            keys_in_pagination_url = list(parsed_qs.keys())
+
+            for key in keys_in_pagination_url:
+                self.params.pop(key, None)
         else:
             # Indicate if this was the last page
             self._finished_iteration = True


### PR DESCRIPTION
### Ticket

https://adroll.atlassian.net/browse/ZUCK-7716

### Description

Remove params keys from URL if `response['paging']['next']` is present (FB bug).

### Motivation and Context

FB SDK is presenting a bug in which the `thumbnails params` values are wiped out during the call, causing the thumbnails to have several dimensions, so, I removed the params for every thumbnail to be the same size.

If in `path` we encounter `response['paging']['next']`, then we remove from `params` tyhe keys inside it.

This new PR was made following these instructions:

https://github.com/SemanticSugar/cats4gold/pull/4903#issuecomment-1150251738