### PR TITLE
use parse_qs and urlparse compatible with python 2.7 and 3

### DIFF
--- a/facebook_business/__init__.py
+++ b/facebook_business/__init__.py
@@ -21,7 +21,7 @@
 from facebook_business.session import FacebookSession
 from facebook_business.api import FacebookAdsApi
 
-__version__ = '14.0.0'
+__version__ = '14.0.0b1'
 __all__ = [
     'session',
     'objects',

--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -33,7 +33,7 @@ from facebook_business.utils import urls
 from contextlib import contextmanager
 import copy
 from six.moves import http_client
-from urllib.parse import parse_qs, urlparse
+
 import os
 import json
 import six
@@ -42,9 +42,11 @@ import re
 try:
   # Since python 3
   from six.moves import collections_abc
+  from urllib.parse import parse_qs, urlparse
 except ImportError:
   # Won't work after python 3.8
   import collections as collections_abc
+  from urlparse import urlparse, parse_qs
 
 from facebook_business.adobjects.objectparser import ObjectParser
 from facebook_business.typechecker import TypeChecker

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebook_business'
-PACKAGE_VERSION = '14.0.0'
+PACKAGE_VERSION = '14.0.0b1'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-business-sdk'


### PR DESCRIPTION
Change to make sure we use a `parse_qs` and `urlparse` compatible with python 3x and python 2.7  
PACKAGE_VERSION=14.0.0b1